### PR TITLE
Remove DoubleCheckedLocking check from Checkstyle config

### DIFF
--- a/codequality/checkstyle.xml
+++ b/codequality/checkstyle.xml
@@ -128,7 +128,6 @@
         <!-- Checks for common coding problems               -->
         <!-- See http://checkstyle.sf.net/config_coding.html -->
         <!-- <module name="AvoidInlineConditionals"/> -->
-        <module name="DoubleCheckedLocking"/>    <!-- MY FAVOURITE -->
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="HiddenField">


### PR DESCRIPTION
The `DoubleCheckedLocking` check is not supported by Checkstyle 5.6 which is the default version used in Gradle 1.4.

Also see the [Checkstyle 5.6 release notes](http://checkstyle.sourceforge.net/releasenotes.html#Release_5.6) and the [Gradle 1.4 release notes](http://www.gradle.org/docs/current/release-notes#updated-default-versions-of-checkstyle-and-codenarc).
