### PR TITLE
fixes charset for international RSS

### DIFF
--- a/rss-edge/webapp/jsp/rss.jsp
+++ b/rss-edge/webapp/jsp/rss.jsp
@@ -14,7 +14,7 @@
  *    See the License for the specific language governing permissions and
  *    limitations under the License.
  */
-%>
+%><%@page contentType="text/html;charset=utf-8" %>
 <%@page import="com.netflix.hystrix.HystrixCommand"%>
 <%@page import="com.netflix.recipes.rss.hystrix.AddRSSCommand"%>
 <%@page import="com.netflix.recipes.rss.hystrix.DeleteRSSCommand"%>


### PR DESCRIPTION
Default jsp page encoding loses non-latin1 characters, for example RSS from:
http://www.e15.cz/rss
Added contentType directive to fix this problem.
